### PR TITLE
feat: update on-v-tag-release workflow for enhanced Rust release features

### DIFF
--- a/.github/workflows/on-v-tag-release.yaml
+++ b/.github/workflows/on-v-tag-release.yaml
@@ -2,13 +2,20 @@ name: On Version Tagged, Build and Publish Rust Binaries
 on:
   push:
     tags:
-    - "v*.*.*"
+      - "v*.*.*"
 
 permissions:
   contents: write
 
 jobs:
   release:
-    uses: harmony-labs/workflow-rust-release/.github/workflows/workflow.yaml@v1.0.0
+    uses: harmony-labs/workflow-rust-release/.github/workflows/workflow.yaml@main
     with:
-      executable_name: "gh-config"
+      binary_name: gh-config
+      crate_name: gh-config-cli
+      homebrew_tap: harmony-labs/homebrew-tap
+      scoop_bucket: harmony-labs/scoop-bucket
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      HOMEBREW_GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
+      SCOOP_GITHUB_TOKEN: ${{ secrets.SCOOP_GITHUB_TOKEN }}

--- a/.github/workflows/on-v-tag-release.yaml
+++ b/.github/workflows/on-v-tag-release.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    uses: harmony-labs/workflow-rust-release/.github/workflows/workflow.yaml@main
+    uses: harmony-labs/workflow-rust-release/.github/workflows/workflow.yaml@v2.0.0
     with:
       binary_name: gh-config
       crate_name: gh-config-cli


### PR DESCRIPTION
- Updated workflow reference to use `main` branch instead of `v1.0.0`
- Renamed `executable_name` input to `binary_name` for consistency
- Added `crate_name`, `homebrew_tap`, and `scoop_bucket` inputs
- Added secrets for `CARGO_REGISTRY_TOKEN`, `HOMEBREW_GITHUB_TOKEN`, and `SCOOP_GITHUB_TOKEN`
- Fixed missing newline at end of file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow to improve compatibility with package distribution platforms and enhance deployment configuration. No changes to the application or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->