### PR TITLE
fix: org name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CONFIG_FILE ?= config.yaml
-GITHUB_ORG ?= harmony-labs
+GITHUB_ORG ?= gitkb
 GITHUB_TOKEN ?=
 RUST_LOG ?= info
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ gh-config --token <your-pat> sync config.yaml --dry-run
 - **Generate config from org:**
 
 ```bash
-gh-config --token <your-pat> sync-from-org config.yaml --org harmony-labs
+gh-config --token <your-pat> sync-from-org config.yaml --org gitkb
 ```
 
 ### Example diff output
@@ -133,7 +133,7 @@ gh-config uses a fully extensible, declarative YAML schema. You can specify any 
 
 **Example `config.yaml`:**
 ```yaml
-org: harmony-labs
+org: gitkb
 repos:
   - name: harmony
     settings:
@@ -261,7 +261,7 @@ cargo build --release
 make build
 make diff CONFIG_FILE=config.yaml
 make sync CONFIG_FILE=config.yaml
-make sync-from-github CONFIG_FILE=config.yaml GITHUB_ORG=harmony-labs
+make sync-from-github CONFIG_FILE=config.yaml GITHUB_ORG=gitkb
 ```
 
 ---

--- a/docs/ci-examples.md
+++ b/docs/ci-examples.md
@@ -125,7 +125,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           RUST_LOG: info
         run: |
-          $HOME/bin/gh-config sync-from-org config.yaml --org harmony-labs
+          $HOME/bin/gh-config sync-from-org config.yaml --org gitkb
       - name: Create PR
         if: env.EXIT_CODE == 1
         uses: peter-evans/create-pull-request@v7

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,7 +45,7 @@ The Makefile provides shortcuts for common tasks:
 make build
 make diff CONFIG_FILE=config.yaml
 make sync CONFIG_FILE=config.yaml
-make sync-from-github CONFIG_FILE=config.yaml GITHUB_ORG=harmony-labs
+make sync-from-github CONFIG_FILE=config.yaml GITHUB_ORG=gitkb
 ```
 
 ## Running the CLI

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ You can provide your GitHub Personal Access Token (PAT) in two ways:
 The configuration file is written in YAML and describes your organization, repositories, teams, users, assignments, and default settings. Below is the schema with all top-level keys and their meanings.
 
 ```yaml
-org: harmony-labs                # (string) Name of the GitHub organization
+org: gitkb                # (string) Name of the GitHub organization
 
 repos:                            # (list) Repository configurations
   - name: my-repo                 # (string) Repository name
@@ -137,9 +137,9 @@ GITHUB_TOKEN=<your-pat> gh-config sync config.yaml --dry-run
 Export your current GitHub org state into a config file.
 
 ```bash
-gh-config --token <your-pat> sync-from-org config.yaml --org harmony-labs
+gh-config --token <your-pat> sync-from-org config.yaml --org gitkb
 # or
-GITHUB_TOKEN=<your-pat> gh-config sync-from-org config.yaml --org harmony-labs
+GITHUB_TOKEN=<your-pat> gh-config sync-from-org config.yaml --org gitkb
 ```
 
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default GitHub organization reference from `harmony-labs` to `gitkb` across configuration and documentation examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gitkb/gh-config-cli/pull/31)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->